### PR TITLE
Refactoring for internal dns servers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "azurerm_virtual_network" "vnet" {
   resource_group_name = "${azurerm_resource_group.rg.name}"
   address_space       = "${var.address_space}"
   location            = "${azurerm_resource_group.rg.location}"
-  dns_servers         = ["${var.lb_private_ip_address}", "${var.microsoft_external_dns}"]
+  dns_servers         = "${var.microsoft_external_dns}"
 }
 
 resource "azurerm_subnet" "sb" {

--- a/variables.tf
+++ b/variables.tf
@@ -20,11 +20,7 @@ variable "env" {
   default = "local"
 }
 
-variable "lb_private_ip_address" {
-  description = "Private IP address of the of the DNS consul cluster loadbalancer"
-}
-
 variable "microsoft_external_dns" {
-  default     = ["168.63.129.16", "172.16.0.10"]
-  description = "List of external DNS servers, default currently including tactical dns."
+  default     = ["127.0.0.1", "168.63.129.16"]
+  description = "List of external DNS servers, default currently includes localhost (for hosts that have their own forwarder) and Azure's recursive resolvers virtual ip."
 }


### PR DESCRIPTION
It was decided that in order to resolve internal domain names hosts will
have dnsmasq configured in a way that will allow us to reach application domain
names by forwarding the dns requests to the correct consul-dns cluster,
therefore we don't need to configure the consul-dns lb ip at vnet level
anymore.