### PR TITLE
remove tactical ip from default external DNS list

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -25,6 +25,6 @@ variable "lb_private_ip_address" {
 }
 
 variable "microsoft_external_dns" {
-  default     = ["168.63.129.16", "172.16.0.10"]
-  description = "List of external DNS servers, default currently including tactical dns."
+  default     = ["168.63.129.16"]
+  description = "List of external DNS servers"
 }


### PR DESCRIPTION
it's now already included in 127.0.0.1 so no need for it