### PR TITLE
Change Ruby version to the installed version to allow install of Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.4.0'
+ruby '2.4.5'
 
 source 'https://rubygems.org/' do
   gem 'test-kitchen'


### PR DESCRIPTION
cnp-1294

This PR is to change the version of Ruby specified in the Gemfile to the one that is installed on the Jenkins nodes.

Notes:
*
*
*
